### PR TITLE
DTO에서 Serializable 인터페이스 제거

### DIFF
--- a/src/main/java/com/project/board/dto/response/ArticleCommentsResponse.java
+++ b/src/main/java/com/project/board/dto/response/ArticleCommentsResponse.java
@@ -2,7 +2,6 @@ package com.project.board.dto.response;
 
 import com.project.board.dto.ArticleCommentDto;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 
 public record ArticleCommentsResponse(
@@ -11,7 +10,7 @@ public record ArticleCommentsResponse(
         LocalDateTime createdAt,
         String email,
         String nickname
-) implements Serializable {
+) {
 
     public static ArticleCommentsResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname) {
         return new ArticleCommentsResponse(id, content, createdAt, email, nickname);

--- a/src/main/java/com/project/board/dto/response/ArticleResponse.java
+++ b/src/main/java/com/project/board/dto/response/ArticleResponse.java
@@ -2,7 +2,6 @@ package com.project.board.dto.response;
 
 import com.project.board.dto.ArticleDto;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 
 public record ArticleResponse(
@@ -13,7 +12,7 @@ public record ArticleResponse(
         LocalDateTime createdAt,
         String email,
         String nickname
-) implements Serializable {
+) {
 
     public static ArticleResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname) {
         return new ArticleResponse(id, title, content, hashtag, createdAt, email, nickname);

--- a/src/main/java/com/project/board/dto/response/ArticleWithCommentResponse.java
+++ b/src/main/java/com/project/board/dto/response/ArticleWithCommentResponse.java
@@ -2,7 +2,6 @@ package com.project.board.dto.response;
 
 import com.project.board.dto.ArticleWithCommentsDto;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -17,7 +16,7 @@ public record ArticleWithCommentResponse(
         String email,
         String nickname,
         Set<ArticleCommentsResponse> articleCommentsRespons
-) implements Serializable {
+) {
 
     public static ArticleWithCommentResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, Set<ArticleCommentsResponse> articleCommentsRespons) {
         return new ArticleWithCommentResponse(id, title, content, hashtag, createdAt, email, nickname, articleCommentsRespons);


### PR DESCRIPTION
직렬화로 Jackson을 사용하므로 Serializable 인터페이스는 필요하지 않으므로 제거